### PR TITLE
fixed items from issue #73

### DIFF
--- a/docs/_layouts/about.html
+++ b/docs/_layouts/about.html
@@ -41,16 +41,26 @@
             </div>
             <div id="bottom-container" class="row">
                 <div class="col d-block d-md-none bottom-nav">
-                    <ul class="nav justify-content-center">
-                        <li class="nav-item">{% include link name="Introduction" path="/about/" %}</li>
-                        <li class="nav-item">{% include link name="Examples" path="/about/examples" %}</li>
-                        <li class="nav-item">{% include link name="Download" path="/download" %}</li>
-                        <li class="nav-item">{% include link name="Processing with p5.js" path="/about/processing" %}</li>
-                        <li class="nav-item">{% include link name="FAQ" path="/about/faq" %}</li>
-                        <li class="nav-item">{% include link name="License" path="/about/license" %}</li>
-                        <li class="nav-item">{% include link name="Issues" path="/about/issues" %}</li>
-                        <li class="nav-item">{% include link name="Contact" path="/about/contact" %}</li>
-                    </ul>
+                    <table class="table">
+                        <tbody>
+                            <tr>
+                                <td class="nav-item">{% include link name="Introduction" path="/about/" %}</td>
+                                <td class="nav-item">{% include link name="Examples" path="/about/examples" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="Download" path="/download" %}</td>
+                                <td class="nav-item">{% include link name="Processing with p5.js" path="/about/processing" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="FAQ" path="/about/faq" %}</td>
+                                <td class="nav-item">{% include link name="License" path="/about/license" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="Issues" path="/about/issues" %}</td>
+                                <td class="nav-item">{% include link name="Contact" path="/about/contact" %}</td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>

--- a/docs/_layouts/development.html
+++ b/docs/_layouts/development.html
@@ -102,20 +102,34 @@
             </div>
             <div id="bottom-container" class="row">
                 <div class="col d-block d-md-none bottom-nav">
-                    <ul class="nav justify-content-center">
-                        <li class="nav-item">{% include link name="Development" path="/dev/" %}</li>
-                        <li class="nav-item">{% include link name="Checkout" path="/dev/checkout" %}</li>
-                        <li class="nav-item">{% include link name="Build" path="/dev/build" %}</li>
-                        <li class="nav-item">{% include link name="Troubleshooting" path="/dev/trouble" %}</li>
-                        <li class="nav-item">{% include link name="Build config" path="/dev/config" %}</li>
-                        <li class="nav-item">{% include link name="Dependencies" path="/dev/dependencies" %}</li>
-                        <li class="nav-item">{% include link name="Documentation" path="/dev/documentation" %}</li>
-                        <li class="nav-item">{% include link name="Tests" path="/dev/tests" %}</li>
-                        <li class="nav-item">{% include link name="Releases" path="/dev/release" %}</li>
-                        <li class="nav-item">{% include link name="Maintenance" path="/dev/maintenance" %}</li>
-                        <li class="nav-item">{% include link name="Plans" path="/dev/plans" %}</li>
-                        <li class="nav-item">{% include link name="Contributing" path="/dev/contributing" %}</li>
-                    </ul>
+                    <table class="table">
+                        <tbody>
+                            <tr>
+                                <td class="nav-item">{% include link name="Development" path="/dev/" %}</td>
+                                <td class="nav-item">{% include link name="Checkout" path="/dev/checkout" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="Build" path="/dev/build" %}</td>
+                                <td class="nav-item">{% include link name="Troubleshooting" path="/dev/trouble" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="Build config" path="/dev/config" %}</td>
+                                <td class="nav-item">{% include link name="Dependencies" path="/dev/dependencies" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="Documentation" path="/dev/documentation" %}</td>
+                                <td class="nav-item">{% include link name="Tests" path="/dev/tests" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="Releases" path="/dev/release" %}</td>
+                                <td class="nav-item">{% include link name="Maintenance" path="/dev/maintenance" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="Plans" path="/dev/plans" %}</td>
+                                <td class="nav-item">{% include link name="Contributing" path="/dev/contributing" %}</td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>

--- a/docs/_layouts/documentation.html
+++ b/docs/_layouts/documentation.html
@@ -107,25 +107,45 @@
             </div>
             <div id="bottom-container" class="row">
                 <div class="col d-block d-md-none bottom-nav">
-                    <ul class="nav justify-content-center">
-                        <li class="nav-item">{% include link name="Getting started" path="/doc/" %}</li>
-                        <li class="nav-item">{% include link name="Javascript runtime" path="/doc/runtime" %}</li>
-                        <li class="nav-item">{% include link name="Console" path="/doc/console" %}</li>
-                        <li class="nav-item">{% include link name="Command line" path="/doc/args" %}</li>
-                        <li class="nav-item">{% include link name="API index" path="/doc/api" %}</li>
-                        <li class="nav-item">{% include link name="Global" path="/doc/global" %}</li>
-                        <li class="nav-item">{% include link name="Window" path="/doc/window" %}</li>
-                        <li class="nav-item">{% include link name="Canvas" path="/doc/canvas" %}</li>
-                        <li class="nav-item">{% include link name="CanvasGradient" path="/doc/canvasgradient" %}</li>
-                        <li class="nav-item">{% include link name="CanvasPattern" path="/doc/canvaspattern" %}</li>
-                        <li class="nav-item">{% include link name="ImageBitmap" path="/doc/imagebitmap" %}</li>
-                        <li class="nav-item">{% include link name="ImageData" path="/doc/imagedata" %}</li>
-                        <li class="nav-item">{% include link name="Path2D" path="/doc/path2d" %}</li>
-                        <li class="nav-item">{% include link name="Codec" path="/doc/codec" %}</li>
-                        <li class="nav-item">{% include link name="File" path="/doc/file" %}</li>
-                        <li class="nav-item">{% include link name="Process" path="/doc/process" %}</li>
-                        <li class="nav-item">{% include link name="Performance" path="/doc/performance" %}</li>
-                    </ul>
+                    <table class="table">
+                        <tbody>
+                            <tr>
+                                <td class="nav-item">{% include link name="Getting started" path="/doc/" %}</td>
+                                <td class="nav-item">{% include link name="Javascript runtime" path="/doc/runtime" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="Console" path="/doc/console" %}</td>
+                                <td class="nav-item">{% include link name="Command line" path="/doc/args" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="API index" path="/doc/api" %}</td>
+                                <td class="nav-item">{% include link name="Global" path="/doc/global" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="Window" path="/doc/window" %}</td>
+                                <td class="nav-item">{% include link name="Canvas" path="/doc/canvas" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="CanvasGradient" path="/doc/canvasgradient" %}</td>
+                                <td class="nav-item">{% include link name="CanvasPattern" path="/doc/canvaspattern" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="ImageBitmap" path="/doc/imagebitmap" %}</td>
+                                <td class="nav-item">{% include link name="ImageData" path="/doc/imagedata" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="Path2D" path="/doc/path2d" %}</td>
+                                <td class="nav-item">{% include link name="Codec" path="/doc/codec" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="File" path="/doc/file" %}</td>
+                                <td class="nav-item">{% include link name="Process" path="/doc/process" %}</td>
+                            </tr>
+                            <tr>
+                                <td class="nav-item">{% include link name="Performance" path="/doc/performance" %}</td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@ layout: about
 title: Window.js
 ---
 
+<br>
 <span class="title"><span class="magenta">**Window.js**</span> is an
 open-source Javascript runtime for desktop graphics programming.
 </span>

--- a/docs/style.css
+++ b/docs/style.css
@@ -91,6 +91,11 @@ body {
   background: var(--blue);
 }
 
+#sidebar-right p {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
 .row div.bottom-nav {
   background-color: var(--dark);
   padding-top: 1rem;
@@ -112,6 +117,10 @@ a {
 
 #bottom-container a {
   color: var(--lighter);
+}
+
+#bottom-container table {
+  border-color: var(--dark);
 }
 
 #documentation-container a:hover {
@@ -247,6 +256,10 @@ pre.highlight .c1 {
   border-spacing: 2px;
   width: 100%;
   color: #393a34;
+}
+
+#content table + p {
+  margin-top: 1rem;
 }
 
 #content table.parameters td {


### PR DESCRIPTION
Fixed four items in issue #73:

1. More space added on frontpage between span.title and navbar (this section is not wrapped in a h1 element, an extra break was added to create space)

![001](https://user-images.githubusercontent.com/15959673/151095335-853abc18-11dc-463a-814e-297a2f60edc1.png)

2. Space added on the right navbar between first and second sections

![002](https://user-images.githubusercontent.com/15959673/151095352-798b2ee4-793d-445f-bc79-3a59bae9d4c1.png)

3. Links at the bottom of the mobile view placed into a table to right-justify content in columns (placed in two columns to provide extra space)

![003](https://user-images.githubusercontent.com/15959673/151095369-dc7a19a7-bdf5-4ca2-8ec0-a09bf4243c20.png)

4. Adjusted margins for paragraphs that follow tables, creates more space.

![004](https://user-images.githubusercontent.com/15959673/151095397-5b9e0e4a-3f8b-426e-b97e-f9721d0ef33f.png)
